### PR TITLE
Changed the timing of applying default style.

### DIFF
--- a/QBFlatButton/Classes/QBFlatButton.m
+++ b/QBFlatButton/Classes/QBFlatButton.m
@@ -94,9 +94,13 @@
     [self setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
 }
 
-- (void)awakeFromNib
-{    
-    [self useDefaultStyle];
+- (id)initWithCoder:(NSCoder *)decoder
+{
+    if (self = [super initWithCoder:decoder])
+    {
+        [self useDefaultStyle];
+    }
+    return self;
 }
 
 - (void)drawRect:(CGRect)rect


### PR DESCRIPTION
Applying the default style in "awakeFromNib" was not good, because the parent class can't customize the properties in its "awakeFromNib".
